### PR TITLE
Minor fixes

### DIFF
--- a/gap_buffer.cpp
+++ b/gap_buffer.cpp
@@ -32,7 +32,7 @@
 
 using namespace std;
 
-GapBuffer::GapBuffer(int gsize) : GAP_SIZE(gsize)
+GapBuffer::GapBuffer(int gsize) : GAP_SIZE(gsize), buffer(NULL)
 {
     InitBuffer(GAP_SIZE);
 
@@ -242,7 +242,7 @@ int GapBuffer::SizeOfGap()
 unsigned int GapBuffer::PointOffset()
 {
 
-    if (point > gapend) {
+    if (point >= gapend) {
         return ((point - buffer) - (gapend - gapstart));
     } else {
         return (point - buffer);
@@ -308,10 +308,16 @@ char GapBuffer::NextChar()
     // point should not be in the gap.
     if (point == gapstart) {
         point = gapend;
-        return *point;
     } 
 
-    return *(++point);    
+    point++;
+
+    // point should not be in the gap.
+    if (point == gapstart) {
+        point = gapend;
+    }
+
+    return *point;
 
 }
 
@@ -363,7 +369,7 @@ void GapBuffer::DeleteChars(unsigned int size)
     gapend += size;
 }
 
-void GapBuffer::InsertString(char *string, unsigned int length)
+void GapBuffer::InsertString(const char *string, unsigned int length)
 {
 
     MoveGapToPoint();

--- a/gap_buffer.h
+++ b/gap_buffer.h
@@ -140,7 +140,7 @@ public:
      *  Inserts a length size string 
      *  at point.
      */
-    void InsertString(char *string, unsigned int length);
+    void InsertString(const char *string, unsigned int length);
 
     /*
      *  Prints out the current buffer from start


### PR DESCRIPTION
@lazyhacker Thank you for publishing this repository!

While using it, I have noticed a few problems. See below for a few test-cases that demonstrate this (make sure to compile in debug mode, otherwise the asserts won't trigger).

Feel free to improve my fixes.

```c
#include <cstdlib>
#include <cassert>
#include <cstring>
#include <new>

#include "gap_buffer.h"

static void TestConstructor()
{
    GapBuffer *buffer = (GapBuffer *)malloc(sizeof(GapBuffer));
    memset(buffer, 0xff, sizeof(GapBuffer));

    // Simulate a constructor that runs on memory that is not zero'd out.
    // On my end, this happened even without the in-place-constructor voodoo.
    // SEGFAULTS if we don't add : buffer(NULL)
    new(buffer) GapBuffer();


    buffer->~GapBuffer();
    free(buffer);
}

static void TestPointOffset()
{
    GapBuffer buffer;

    buffer.InsertString((char *)"abc", 3);
    buffer.SetPoint(0);
    buffer.DeleteChars(1);
    buffer.SetPoint(1);
    buffer.PreviousChar();
    buffer.PrintBuffer();
    assert(buffer.PointOffset() == 0);
}

static void TestNextChar()
{
    { // Works.
        GapBuffer buffer;

        buffer.InsertString((char *)"abcd", 4);
        buffer.SetPoint(0);
        char c = buffer.NextChar();
        assert(c == 'b');
    }

    { // Fails.
        GapBuffer buffer;

        buffer.InsertString((char *)"abcd", 4);
        buffer.SetPoint(0);
        buffer.DeleteChars(2);
        char c = buffer.NextChar();
        assert(c == 'd');
    }

    { // Fails.
        GapBuffer buffer;

        buffer.InsertString((char *)"abc", 3);
        buffer.SetPoint(1);
        buffer.DeleteChars(1);
        buffer.SetPoint(0);
        char c = buffer.NextChar();
        assert(c == 'c');
    }
}

int main()
{
    TestConstructor();
    TestPointOffset();
    TestNextChar();

    return EXIT_SUCCESS;
}
```